### PR TITLE
Simplify dependencies, and use web repos instead.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,59 +1,68 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mycompany</groupId>
     <artifactId>UltraCosmetics</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <build>
-        <finalName>${project.name}</finalName>
-        <resources>
-            <resource>
-                <targetPath>.</targetPath>
-                <filtering>true</filtering>
-                <directory>${basedir}/src/main/resources</directory>
-                <includes>
-                    <include>**/*</include>
-                </includes>
-            </resource>
-        </resources>
-    </build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                  <source>1.7</source>
+                  <target>1.7</target>
+              </configuration>
+          </plugin>
+          <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <configuration>
+          <!-- put your configurations here -->
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      </plugins>
+   </build>
+    <repositories>
+	    <repository>
+	        <id>spigot-repo</id>
+	        <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+	    </repository>
+        <repository>
+            <id>vault-repo</id>
+            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+        </repository>
+        <repository>
+		    <id>md5</id>
+		    <url>http://repo.md-5.net/content/groups/public</url>
+		</repository>
+    </repositories>
     <dependencies>
         <dependency>
-            <groupId>Spigot1.11_R1</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.11_R1</version>
+           <groupId>org.spigotmc</groupId>
+           <artifactId>spigot-api</artifactId>
+           <version>1.11-R0.1-SNAPSHOT</version>
+           <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>LibsDisguises</groupId>
-            <artifactId>libsdisguises</artifactId>
-            <version>libsdisguises</version>
-        </dependency>
+		<dependency>
+		    <groupId>LibsDisguises</groupId>
+		    <artifactId>LibsDisguises</artifactId>
+		    <version>9.2.4</version>
+		</dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.6</version>
-        </dependency>
-        <dependency>
-            <groupId>Spigot1.10_R1</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.10_R1</version>
-        </dependency>
-        <dependency>
-            <groupId>Spigot1._9R1</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.9_R1</version>
-        </dependency>
-        <dependency>
-            <groupId>Spigot1.9_R2</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.9_R2</version>
-        </dependency>
-        <dependency>
-            <groupId>Spigot1.8_R3</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.8_R3</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
Use the public web repos to pull in the maven dependencies instead of local files in the resources folder.